### PR TITLE
Bump Catch2 3.0.1 -> 3.4.0

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,7 +12,7 @@ if(NOT ${Catch2_FOUND})
     FetchContent_Declare(
         Catch2
         GIT_REPOSITORY https://github.com/catchorg/Catch2
-        GIT_TAG v3.0.1
+        GIT_TAG v3.4.0
     )
     FetchContent_MakeAvailable(Catch2)
 endif()


### PR DESCRIPTION
The Catch2 version needed to be updated to work with gcc 13.